### PR TITLE
Audit comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 .env
 
 .DS_Store
+
+# Ignore dependencies
+*/vendor

--- a/01-Authentication-RS256/Dockerfile
+++ b/01-Authentication-RS256/Dockerfile
@@ -1,3 +1,4 @@
+# Ruby 2.3.3 is very outdated and past any security support
 FROM ruby:2.3.3
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir /myapp

--- a/01-Authentication-RS256/Gemfile
+++ b/01-Authentication-RS256/Gemfile
@@ -2,6 +2,7 @@
 source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+# This version of rails is outdated and is past any security support
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 
 # Use Puma as the app server

--- a/01-Authentication-RS256/app/controllers/private_controller.rb
+++ b/01-Authentication-RS256/app/controllers/private_controller.rb
@@ -2,6 +2,8 @@
 class PrivateController < ActionController::API
   include Secured
 
+  # I would avoid using reserved words as function names,
+  # this is technically allowed, but I don't think it's a good practice
   def private
     render json: { message: 'Hello from a private endpoint! You need to be authenticated to see this.' }
   end

--- a/01-Authentication-RS256/config/application.rb
+++ b/01-Authentication-RS256/config/application.rb
@@ -4,6 +4,7 @@ require_relative 'boot'
 require 'rails'
 
 # Pick the frameworks you want:
+# The only module we use for this tutorial is the action_controller, we can safely remove all others
 require 'active_job/railtie'
 require 'action_controller/railtie'
 require 'action_mailer/railtie'

--- a/01-Authentication-RS256/config/routes.rb
+++ b/01-Authentication-RS256/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  # The modern syntax for routing is now as follows:
+  # get 'api/public', to: 'public#public'
   get 'api/public' => 'public#public'
   get 'api/private' => 'private#private'
   get 'api/private-scoped' => 'private#private_scoped'

--- a/01-Authentication-RS256/config/secrets.yml
+++ b/01-Authentication-RS256/config/secrets.yml
@@ -10,6 +10,8 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+# Rails now use config/master.key (not committed) and credentials.yml.enc to store and encrypt secrets
+
 development:
   secret_key_base: c1b9818f0129766c4c11b5ef0cfec6b3ec125a46c38814a24a6a013e1ded199542c6c2b53afe1594a3fa1814122dc594c09338c5983f52299f88f75f91c9b75a
   auth0_domain: <%= ENV["AUTH0_DOMAIN"] %>


### PR DESCRIPTION
# Code Audit

## Repo description
This repo contains two Rails apps, both cover the [Auth0 Rails Quickstart](https://auth0.com/docs/quickstart/backend/rails) using different signing algorithms, so one uses `RS256` and the other `HS256`. Both apps are mostly the same except for the `jwt_web_token.rb` file which performs the token validation and each algorithm has different ways to do so.

Both apps focuses on 3 endpoints:

- A public endpoint without any kind of access control.
- A private endpoint that needs an authentication token to proceed.
- A private endpoint that needs an authentication token and a scope to proceed.

The private endpoints make requests to the Auth0 API (which was created by following the tutorial), then they validate the response to determine if the request was authenticated or not.